### PR TITLE
Add missing owner badge at publish

### DIFF
--- a/chapter3/exercise1/README.md
+++ b/chapter3/exercise1/README.md
@@ -7,7 +7,7 @@ Follow the steps in [the code file](code/src/lib.rs) and don't hesitate to valid
 1. Reset your ledger with: `resim reset`
 1. Create a new default account: `resim new-account` -> Store the address of the account somewhere.
 1. Create an owner badge: `resim new-simple-badge`
-1. Publish your code: `resim publish ./code`
+1. Publish your code: `resim publish ./code --owner-badge [owner_badge_NFAddress]`
 1. Instantiate a new component: `resim call-function [package_address] Exercise1 instantiate_exercise` -> Save the returned component address and first resource address. This first resource address represents the banana resource.
 1. Call the `mint_apple` method: `resim call-method [component_address] mint_apple`
 1. Take a look at the resources in your account: `resim show [account_address]`


### PR DESCRIPTION
I believe --owner-badge is something that is needed upon publishing, without it I got an "Error: OwnerBadgeNotSpecified".  So here is my PR for fixing the missing badge.